### PR TITLE
Modifications so that Mongomatic will work with JRuby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,7 +13,6 @@ begin
     gem.files = ["lib/**/*.rb"]
     gem.add_development_dependency "shoulda", ">= 2.11.1"
     gem.add_dependency "bson", "= 1.0.7"
-    gem.add_dependency "bson_ext", "= 1.0.7"
     gem.add_dependency "mongo", "= 1.0.8"
     gem.add_dependency "activesupport", ">= 2.3.5"
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings

--- a/lib/mongomatic.rb
+++ b/lib/mongomatic.rb
@@ -1,5 +1,4 @@
 gem "bson", ">= 1.0.4"
-gem "bson_ext", ">= 1.0.4"
 gem "mongo", ">= 1.0.7"
 gem "activesupport", ">= 2.3.5"
 

--- a/lib/mongomatic/cursor.rb
+++ b/lib/mongomatic/cursor.rb
@@ -14,15 +14,10 @@ module Mongomatic
     def initialize(obj_class, mongo_cursor)
       @obj_class    = obj_class
       @mongo_cursor = mongo_cursor
-      
-      @mongo_cursor.public_methods(false).each do |meth|
-        next if self.methods.collect { |meth| meth.to_sym }.include?(meth.to_sym)
-        (class << self; self; end).class_eval do
-          define_method meth do |*args|
-            @mongo_cursor.send meth, *args
-          end
-        end
-      end
+    end
+
+    def method_missing(name, *args)
+      @mongo_cursor.send name, *args
     end
     
     # Is the cursor empty? This method is much more efficient than doing cursor.count == 0


### PR DESCRIPTION
I'm proposing some changes that will allow Mongomatic to work under JRuby:
- Remove bson_ext from the gem dependencies and require statement - This isn't needed for Mongomatic to work properly. If it is present, it will be loaded without needing a require statement.
- Changes to Mongomatic::Cursor - This seems like a proxy object to Mongo::Cursor. The way that the code was going about passing methods through was to create methods on Mongomatic::Cursor at instantiation which would send the call to Mongo::Cursor. For some reason, JRuby wasn't picking up has_next? as one of Mongo::Cursor's public methods so it wasn't getting added to Mongomatic::Cursor. I changed the proxying method to use method_missing instead of adding methods when the object is created. This seems to work well in JRuby and MRI.

I was able to get the test suite to pass in MRI 1.8.7, MRI 1.9.1 and JRuby 1.5.2.
