### PR TITLE
Fix in #hash_for_field to handle nested array indexes

### DIFF
--- a/lib/mongomatic/base.rb
+++ b/lib/mongomatic/base.rb
@@ -242,6 +242,7 @@ module Mongomatic
     
     def hash_for_field(field, break_if_dne=false)
       parts = field.split(".")
+      parts.map! { |i| i =~ /^\d+$/ ? i.to_i : i }
       curr_hash = self.doc
       return [parts[0], curr_hash] if parts.size == 1
       field = parts.pop # last one is the field


### PR DESCRIPTION
Came up with this limitation when trying to do something like:
self.inc "tasks.0.hours", 1
and saw #hash_for_field didn't typecast indexes for nested arrays

Run the tests, didn't see anything broken O=)

Thanks and kind regards,

Lorenzo
