### PR TITLE
#do_callback should not raise NoMethodErrors raised in callbacks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,8 +12,8 @@ begin
     gem.authors = ["Ben Myles"]
     gem.files = ["lib/**/*.rb"]
     gem.add_development_dependency "shoulda", ">= 2.11.1"
-    gem.add_dependency "bson", "= 1.1"
-    gem.add_dependency "mongo", "= 1.1"
+    gem.add_dependency "bson", "~> 1.1.0"
+    gem.add_dependency "mongo", "~> 1.1.0"
     gem.add_dependency "activesupport", ">= 2.3.5"
     # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
   end

--- a/lib/mongomatic.rb
+++ b/lib/mongomatic.rb
@@ -1,5 +1,5 @@
-gem "bson", "= 1.1"
-gem "mongo", "= 1.1"
+gem "bson", "~> 1.1.0"
+gem "mongo", "~> 1.1.0"
 gem "activesupport", ">= 2.3.5"
 
 require "bson"

--- a/lib/mongomatic/base.rb
+++ b/lib/mongomatic/base.rb
@@ -72,11 +72,8 @@ module Mongomatic
       private
       
       def do_callback(meth)
-        begin
-          send(meth)
-        rescue NoMethodError => e
-          false
-        end
+        return false unless respond_to?(meth, true)
+        send(meth)
       end
     end
 
@@ -254,11 +251,8 @@ module Mongomatic
     end
     
     def do_callback(meth)
-      begin
-        send(meth)
-      rescue NoMethodError => e
-        false
-      end
+      return false unless respond_to?(meth, true)
+      send(meth)
     end
   end
 end

--- a/mongomatic.gemspec
+++ b/mongomatic.gemspec
@@ -48,19 +48,19 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_development_dependency(%q<shoulda>, [">= 2.11.1"])
-      s.add_runtime_dependency(%q<bson>, ["= 1.1"])
-      s.add_runtime_dependency(%q<mongo>, ["= 1.1"])
+      s.add_runtime_dependency(%q<bson>, ["~> 1.1.0"])
+      s.add_runtime_dependency(%q<mongo>, ["~> 1.1.0"])
       s.add_runtime_dependency(%q<activesupport>, [">= 2.3.5"])
     else
       s.add_dependency(%q<shoulda>, [">= 2.11.1"])
-      s.add_dependency(%q<bson>, ["= 1.1"])
-      s.add_dependency(%q<mongo>, ["= 1.1"])
+      s.add_dependency(%q<bson>, ["~> 1.1.0"])
+      s.add_dependency(%q<mongo>, ["~> 1.1.0"])
       s.add_dependency(%q<activesupport>, [">= 2.3.5"])
     end
   else
     s.add_dependency(%q<shoulda>, [">= 2.11.1"])
-    s.add_dependency(%q<bson>, ["= 1.1"])
-    s.add_dependency(%q<mongo>, ["= 1.1"])
+    s.add_dependency(%q<bson>, ["~> 1.1.0"])
+    s.add_dependency(%q<mongo>, ["~> 1.1.0"])
     s.add_dependency(%q<activesupport>, [">= 2.3.5"])
   end
 end

--- a/test/test_mongomatic.rb
+++ b/test/test_mongomatic.rb
@@ -191,7 +191,6 @@ class TestMongomatic < Test::Unit::TestCase
     p.callback_tests = []
     assert p.callback_tests.empty?
     assert p.valid?
-    p p.callback_tests
     assert_equal [:before_validate, :after_validate], p.callback_tests
     p.callback_tests = []
     assert p.insert.is_a?(BSON::ObjectId)

--- a/test/test_mongomatic.rb
+++ b/test/test_mongomatic.rb
@@ -191,6 +191,7 @@ class TestMongomatic < Test::Unit::TestCase
     p.callback_tests = []
     assert p.callback_tests.empty?
     assert p.valid?
+    p p.callback_tests
     assert_equal [:before_validate, :after_validate], p.callback_tests
     p.callback_tests = []
     assert p.insert.is_a?(BSON::ObjectId)
@@ -620,5 +621,20 @@ class TestMongomatic < Test::Unit::TestCase
     assert_equal "And Value", p.value_for_key("employer.something_else.with_a_key")
     assert_equal "Meta+Level Games", p.value_for_key("employer.name")
     assert_nil p.value_for_key("some_key.that_does_not.exist")
+  end
+
+  should "not rescue a NoMethodError raised in a callback" do
+    class Thing < Mongomatic::Base
+      def before_insert
+        raise NoMethodError
+      end
+
+      def self.before_drop
+        raise NoMethodError
+      end
+    end
+
+    assert_raise(NoMethodError) { Thing.new.insert }
+    assert_raise(NoMethodError) { Thing.drop }
   end
 end


### PR DESCRIPTION
This commit resolves a bug we encountered with a callback that had some fairly complex stuff happening inside.

```
class Person < Mongomatic::Base
  def before_insert
    foo # buggy method raises a NoMethodError
    bar
  end
end

Person.new.insert # bar never gets executed
                  # and the error does not bubble up,
                  # resulting in many a puzzled look
```

Also ended up relaxing some version requirements a little.

Cheers.
