### PR TITLE
Implemented Mongomatic::Base#delete

### DIFF
--- a/lib/mongomatic/base.rb
+++ b/lib/mongomatic/base.rb
@@ -147,7 +147,18 @@ module Mongomatic
       field, hash = hash_for_field(key.to_s, true)
       hash[field]
     end
-    
+   
+    ##
+    # Same as Hash#delete
+    #
+    # mydoc.delete("name")
+    #  => "Ben"
+    # mydoc.has_hey?("name")
+    #  => false
+    def delete(key)
+      @doc.delete(key)
+    end
+
     # Fetch a field (just like a hash):
     #  mydoc["name"]
     #   => "Ben"


### PR DESCRIPTION
Hey there,

I went ahead and implemented Mongomatic::Base#delete to mimic Hash#delete. All your test cases still pass. I did not add a new test case, because the method is horribly simple (it simply passes the call down to the underlying Hash instance), and you didn't seem to test your hash accessors either.

Kind regards,
Michishige Kaito
