### PR TITLE
Remove support for Rails 2.x activesupport library

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,8 +1,9 @@
 = 0.8.1
- * Add Mongomatic::Base#insert and Mongomatic::Base#insert!
+ * Add Mongomatic::Base#insert and Mongomatic::Base#insert! (jsmestad)
 
 = 0.8.0
- * Change default collection name to MyClass => my_class (Justin Smestad)
+ * Change default collection name to MyClass => my_class (jsmestad)
+ * Dropped explicit support for Rails 2.x's ActiveSupport library (jsmestad)
 
 = 0.7.3
  * transaction() can now take a hash with :scope

--- a/mongomatic.gemspec
+++ b/mongomatic.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Ben Myles"]
-  s.date = %q{2011-03-31}
+  s.date = %q{2011-04-06}
   s.description = %q{Mongomatic is a simple Ruby object mapper for Mongo}
   s.email = %q{ben.myles@gmail.com}
   s.extra_rdoc_files = [
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   ]
   s.homepage = %q{http://mongomatic.com/}
   s.require_paths = ["lib"]
-  s.rubygems_version = %q{1.5.3}
+  s.rubygems_version = %q{1.7.2}
   s.summary = %q{Mongomatic is a simple Ruby object mapper for Mongo}
   s.test_files = [
     "test/helper.rb",


### PR DESCRIPTION
Dont see the huge need for this at this point. Rails 3 is a year old now.
